### PR TITLE
Use curl instead of nc to check server status.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure(2) do |config|
 
   $script = <<SCRIPT
   # curl localhost and get the http response code
-  while ! nc -z localhost 2020; do
+  while ! curl -Is localhost:2020 -o /dev/null; do
     sleep 1 && echo -n .
   done
   http_code=$(curl --silent --head --output /dev/null -w '%{http_code}' localhost:2020)


### PR DESCRIPTION
Salut Antoine,

Dans CentOS 7, `nc` est en fait `nmap-ncat` et ne possède pas d'option `-z` pour scanner. Je propose donc d'utiliser `curl` pour vérifier si le serveur est en ligne. Testé sous CentOS 7 et tout fonctionne.