### PR TITLE
Use Caddy Service configurations from vendor

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 # defaults file for caddy-ansible
+caddy_user: www-data
+caddy_home: /home/caddy
 caddy_email: foo@foo.bar
 caddy_features: git
 caddy_update: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,32 +2,32 @@
 - include: packages-{{ ansible_pkg_mgr }}.yml
 
 - name: Create Caddy user
-  user: name=caddy system=yes createhome=yes
+  user: name={{ caddy_user }} system=yes createhome=yes home={{ caddy_home }}
 
 - name: Get all Caddy releases
-  get_url: url=https://api.github.com/repos/mholt/caddy/git/refs/tags dest=/home/caddy/releases.txt force=yes
+  get_url: url=https://api.github.com/repos/mholt/caddy/git/refs/tags dest={{ caddy_home }}/releases.txt force=yes
   when: caddy_update
   register: caddy_releases_cache
 
 - name: Set Caddy features
-  copy: content="{{caddy_features}}" dest=/home/caddy/features.txt
+  copy: content="{{caddy_features}}" dest={{ caddy_home }}/features.txt
   when: caddy_update
   register: caddy_features_cache
 
 - name: Download Caddy
-  get_url: url=https://caddyserver.com/download/build?os=linux&arch=amd64&features={{caddy_features}} dest=/home/caddy/caddy.tar.gz force=yes
+  get_url: url=https://caddyserver.com/download/build?os=linux&arch=amd64&features={{caddy_features}} dest={{ caddy_home }}/caddy.tar.gz force=yes
   when: caddy_releases_cache.changed or caddy_features_cache.changed
   register: caddy_binary_cache
 
 - name: Download Caddy
-  get_url: url=https://caddyserver.com/download/build?os=linux&arch=amd64&features={{caddy_features}} dest=/home/caddy/caddy.tar.gz
+  get_url: url=https://caddyserver.com/download/build?os=linux&arch=amd64&features={{caddy_features}} dest={{ caddy_home }}/caddy.tar.gz
 
 - name: Extract Caddy
-  unarchive: src=/home/caddy/caddy.tar.gz dest=/usr/bin/ copy=no
+  unarchive: src={{ caddy_home }}/caddy.tar.gz dest=/usr/bin/ copy=no
   when: caddy_binary_cache.changed
 
 - name: Extract Caddy
-  unarchive: src=/home/caddy/caddy.tar.gz dest=/usr/bin/ creates=/usr/bin/caddy copy=no
+  unarchive: src={{ caddy_home }}/caddy.tar.gz dest=/usr/bin/ creates=/usr/bin/caddy copy=no
 
 - name: Check if the binary can bind to TCP port <1024
   shell: getcap /usr/bin/caddy | grep cap_net_bind_service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,7 @@
     - /etc/caddy
     - /etc/ssl/caddy
     - /var/www
+    - /var/log/caddy
 
 - name: Create Caddyfile
   copy: content="{{caddy_config}}" dest=/etc/caddy/Caddyfile

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,16 +37,18 @@
   shell: getcap /usr/bin/caddy | grep cap_net_bind_service
   failed_when: False
   changed_when: False
+  when: not caddy_init_system or caddy_init_system == "upstart"
   register: caddy_bind_cap
 
 - name: Set capability on the binary file to be able to bind to TCP port <1024
   command: setcap cap_net_bind_service=+ep /usr/bin/caddy
-  when: caddy_bind_cap.rc > 0
+  when: not caddy_init_system or caddy_init_system == "upstart" and caddy_bind_cap.rc > 0
 
 - name: Create directories
-  file: path={{ item }} state=directory owner=caddy
+  file: path={{ item }} state=directory owner={{ caddy_user }} mode=0770
   with_items:
     - /etc/caddy
+    - /etc/ssl/caddy
     - /var/www
 
 - name: Create Caddyfile
@@ -59,9 +61,19 @@
   when: not caddy_init_system or caddy_init_system == "upstart"
   notify: Restart Caddy
 
-- name: Systemd service
-  template: src=caddy.service dest=/etc/systemd/system/caddy.service
+# this may also be copied later on - currently packaged file does not contain the features
+- name: Systemd service | get config from github
+  get_url: url=https://raw.githubusercontent.com/mholt/caddy/master/dist/init/linux-systemd/caddy.service dest=/etc/systemd/system/caddy.service mode=0755
   ignore_errors: yes
+  when: not caddy_init_system or caddy_init_system == "systemd"
+  notify: Reload systemd service file
+
+- name: Systemd service | set ExecStart
+  lineinfile: 
+    state: present
+    dest: /etc/systemd/system/caddy.service
+    regexp: '^ExecStart\='
+    line: 'ExecStart=/usr/bin/caddy -log stdout -agree=true -email {{ caddy_email }} -conf=/etc/caddy/Caddyfile -root=/var/www'
   when: not caddy_init_system or caddy_init_system == "systemd"
   notify: Reload systemd service file
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,11 +23,14 @@
   get_url: url=https://caddyserver.com/download/build?os=linux&arch=amd64&features={{caddy_features}} dest={{ caddy_home }}/caddy.tar.gz
 
 - name: Extract Caddy
-  unarchive: src={{ caddy_home }}/caddy.tar.gz dest=/usr/bin/ copy=no
+  unarchive: src={{ caddy_home }}/caddy.tar.gz dest={{ caddy_home }} copy=no
   when: caddy_binary_cache.changed
 
 - name: Extract Caddy
-  unarchive: src={{ caddy_home }}/caddy.tar.gz dest=/usr/bin/ creates=/usr/bin/caddy copy=no
+  unarchive: src={{ caddy_home }}/caddy.tar.gz dest={{ caddy_home }} creates={{ caddy_home }}/caddy copy=no
+
+- name: Copy Caddy Binary
+  copy: src={{ caddy_home }}/caddy dest=/usr/bin/ remote_src=True
 
 - name: Check if the binary can bind to TCP port <1024
   shell: getcap /usr/bin/caddy | grep cap_net_bind_service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,6 +68,7 @@
   when: not caddy_init_system or caddy_init_system == "systemd"
   notify: Reload systemd service file
 
+# In the future, we may add relevant parameters to Caddyfile instead of modifying the call
 - name: Systemd service | set ExecStart
   lineinfile: 
     state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,9 +55,8 @@
   copy: content="{{caddy_config}}" dest=/etc/caddy/Caddyfile
   notify: Restart Caddy
 
-- name: Upstart service
-  template: src=caddy.conf dest=/etc/init/caddy.conf
-  ignore_errors: yes
+- name: Upstart service | copy from caddy distribution
+  copy: src={{ caddy_home }}/init/linux-upstart/caddy.conf dest=/etc/init/caddy.conf mode=0644 remote_src=True 
   when: not caddy_init_system or caddy_init_system == "upstart"
   notify: Restart Caddy
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,8 @@
   unarchive: src={{ caddy_home }}/caddy.tar.gz dest={{ caddy_home }} creates={{ caddy_home }}/caddy copy=no
 
 - name: Copy Caddy Binary
-  copy: src={{ caddy_home }}/caddy dest=/usr/bin/ remote_src=True
+  copy: src={{ caddy_home }}/caddy dest=/usr/bin/ mode=0755 remote_src=True
+  notify: Restart Caddy
 
 - name: Check if the binary can bind to TCP port <1024
   shell: getcap /usr/bin/caddy | grep cap_net_bind_service


### PR DESCRIPTION
This pull request replaces https://github.com/antoiner77/caddy-ansible/pull/18

It reogranizes code to support using the provided service files for start/stop/restart caddy on upstart and systemd.

- using more variables like caddy_home and caddy_user
- refactor package extracton
- (conditional) getting/copying systemd and upstart files
- set (conditional) requirements for runtime