### PR TITLE
The unarchive module needs Ansible 1.6

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
   # - CC-BY
   license: license (GPLv2, CC-BY, etc)
 
-  min_ansible_version: 1.2
+  min_ansible_version: 1.6
 
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your


### PR DESCRIPTION
The `creates` option is used, which is added in Ansible 1.6
For those using Ubuntu 14.04: `sudo apt-add-repository ppa:ansible/ansible`

Also, python 2.7.9+ is required to connect to api.github.com:443 (SNI support)
For those using Ubuntu 14.04: `sudo add-apt-repository ppa:fkrull/deadsnakes-python2.7`