### PR TITLE
Add tls email in example, fixes caddy starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Example Playbook
       caddy_config: |
         localhost:2020
         gzip
+        
+        tls email@example.com
+        
         root /var/www
         git github.com/antoiner77/caddy-ansible /
 ```


### PR DESCRIPTION
This fixes caddy not starting right away after provisioning - by default it requests this from the user (I think maybe only if there is a port that uses 443) but it wasn't clear error since it's started automatically.

https://caddyserver.com/docs/tls