### PR TITLE
use `caddy_user` in user/group settings on service

### DIFF
--- a/templates/caddy.service
+++ b/templates/caddy.service
@@ -1,6 +1,6 @@
 ; source: https://github.com/mholt/caddy/blob/master/dist/init/linux-systemd/caddy.service
 ; version: 7dc23b1
-; changes: none
+; changes: 2017-01-16 klauern - parameterize User/Group with template variable 'caddy_user'
 
 [Unit]
 Description=Caddy HTTP/2 web server

--- a/templates/caddy.service
+++ b/templates/caddy.service
@@ -12,8 +12,8 @@ Wants=network-online.target systemd-networkd-wait-online.service
 Restart=on-failure
 
 ; User and group the process will run as.
-User=www-data
-Group=www-data
+User={{caddy_user}}
+Group={{caddy_user}}
 
 ; Letsencrypt-issued certificates will be written to this directory.
 Environment=CADDYPATH=/etc/ssl/caddy


### PR DESCRIPTION
It appears you have defaulted to using `www-data` for the user/group combo for the SystemD service, but you do use a `caddy_user` default variable.  I don't run as `www-data`, so I thought it easier to just change this template to run as that parameterized user instead.