### PR TITLE
Factor certificates dir as default configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ caddy_update: yes
 caddy_bin_dir: /usr/local/bin
 caddy_conf_dir: /etc/caddy
 caddy_log_file: stdout
+caddy_certs_dir: /etc/ssl/caddy
 caddy_config: |
   localhost:2020
   gzip

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
   file: path={{ item }} state=directory owner={{ caddy_user }} mode=0700
   with_items:
     - "{{ caddy_conf_dir }}"
-    - /etc/ssl/caddy
+    - "{{ caddy_certs_dir }}"
 
 - name: Create Caddyfile
   copy: content="{{ caddy_config }}" dest="{{ caddy_conf_dir }}/Caddyfile" owner={{ caddy_user }}

--- a/templates/caddy.conf
+++ b/templates/caddy.conf
@@ -1,5 +1,5 @@
 # source: https://github.com/mholt/caddy/blob/master/dist/init/linux-upstart/caddy.conf
-# version: fea0d5a
+# version: 6be0386
 # changes: Set variables via Ansible
 
 description "Caddy HTTP/2 web server"
@@ -18,12 +18,12 @@ respawn limit 10 5
 reload signal SIGUSR1
 
 # Let's Encrypt certificates will be written to this directory.
-env CADDYPATH=/etc/caddy
+env CADDYPATH={{ caddy_certs_dir }}
 
 limit nofile 1048576 1048576
 
 script
-        cd /etc/caddy
+        cd {{ caddy_certs_dir }}
         rootdir="$(mktemp -d -t "caddy-run.XXXXXX")"
         exec {{ caddy_bin_dir }}/caddy -agree -log={{ caddy_log_file }} -conf={{ caddy_conf_dir }}/Caddyfile -root=$rootdir
 end script

--- a/templates/caddy.conf.centos-6
+++ b/templates/caddy.conf.centos-6
@@ -1,5 +1,5 @@
 # source: https://github.com/mholt/caddy/blob/master/dist/init/linux-upstart/caddy.conf.centos-6
-# version: 7dc23b1
+# version: 6be0386
 # changes: Set variables via Ansible
 
 description "Caddy HTTP/2 web server"
@@ -21,12 +21,12 @@ respawn limit 10 5
 reload signal SIGUSR1
 
 # Let's Encrypt certificates will be written to this directory.
-env CADDYPATH=/etc/caddy
+env CADDYPATH={{ caddy_certs_dir }}
 
 limit nofile 1048576 1048576
 
 script
-        cd /etc/caddy
+        cd {{ caddy_certs_dir }}
         rootdir="$(mktemp -d -t "caddy-run.XXXXXX")"
         exec {{ caddy_bin_dir }}/caddy -agree -log=stdout -conf={{ caddy_conf_dir }}/Caddyfile -root=$rootdir
 end script

--- a/templates/caddy.conf.ubuntu-12.04
+++ b/templates/caddy.conf.ubuntu-12.04
@@ -1,5 +1,5 @@
 # source: https://github.com/mholt/caddy/blob/master/dist/init/linux-upstart/caddy.conf.ubuntu-12.04
-# version: 7dc23b1
+# version: 6be0386
 # changes: Set variables via Ansible
 
 description "Caddy HTTP/2 web server"
@@ -19,12 +19,12 @@ respawn limit 10 5
 #reload signal SIGUSR1
 
 # Let's Encrypt certificates will be written to this directory.
-env CADDYPATH=/etc/caddy
+env CADDYPATH={{ caddy_certs_dir }}
 
 limit nofile 1048576 1048576
 
 script
-        cd /etc/caddy
+        cd {{ caddy_certs_dir }}
         rootdir="$(mktemp -d -t "caddy-run.XXXXXX")"
         exec {{ caddy_bin_dir }}/caddy -agree -log={{ caddy_log_file }} -conf={{ caddy_conf_dir }}/Caddyfile -root=$rootdir
 end script

--- a/templates/caddy.service
+++ b/templates/caddy.service
@@ -1,5 +1,5 @@
 ; source: https://github.com/mholt/caddy/blob/master/dist/init/linux-systemd/caddy.service
-; version: 466269f
+; version: 6be0386
 ; changes: Set variables via Ansible
 
 [Unit]
@@ -18,7 +18,7 @@ User={{caddy_user}}
 Group={{caddy_user}}
 
 ; Letsencrypt-issued certificates will be written to this directory.
-Environment=CADDYPATH=/etc/ssl/caddy
+Environment=CADDYPATH={{ caddy_certs_dir }}
 
 ; Always set "-root" to something safe in case it gets forgotten in the Caddyfile.
 ExecStart={{ caddy_bin_dir }}/caddy -log {{ caddy_log_file }} -agree=true -conf={{ caddy_conf_dir }}/Caddyfile -root=/var/tmp
@@ -37,9 +37,9 @@ PrivateDevices=true
 ProtectHome=true
 ; Make /usr, /boot, /etc and possibly some more folders read-only.
 ProtectSystem=full
-; … except /etc/ssl/caddy, because we want Letsencrypt-certificates there.
+; … except {{ caddy_certs_dir }}, because we want Letsencrypt-certificates there.
 ;   This merely retains r/w access rights, it does not add any new. Must still be writable on the host!
-ReadWriteDirectories=/etc/ssl/caddy
+ReadWriteDirectories={{ caddy_certs_dir }}
 
 ; The following additional security directives only work with systemd v229 or later.
 ; They further retrict privileges that can be gained by caddy. Uncomment if you like.


### PR DESCRIPTION
This follows upstream making the dir the same across init scripts -
see https://github.com/mholt/caddy/pull/1541