### PR TITLE
More configuration variables for systemd caddy.service.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,10 @@ caddy_bin_dir: /usr/local/bin
 caddy_conf_dir: /etc/caddy
 caddy_log_file: stdout
 caddy_certs_dir: /etc/ssl/caddy
+caddy_systemd_network_dependency: True
+caddy_systemd_restart: "on-failure" # alway, on-success, on-failure, on-abnormal, on-abort, on-watchdog
+caddy_systemd_restart_startlimitinterval: "86400"
+caddy_systemd_restart_startlimitburst: "5"
 caddy_systemd_private_tmp: "true"
 caddy_systemd_private_devices: "true"
 caddy_systemd_protect_home: "true"

--- a/templates/caddy.service
+++ b/templates/caddy.service
@@ -1,3 +1,5 @@
+; {{ ansible_managed }}
+;
 ; source: https://github.com/mholt/caddy/blob/master/dist/init/linux-systemd/caddy.service
 ; version: 6be0386
 ; changes: Set variables via Ansible
@@ -6,12 +8,14 @@
 Description=Caddy HTTP/2 web server
 Documentation=https://caddyserver.com/docs
 After=network-online.target
+{% if caddy_systemd_network_dependency == true %}
 Wants=network-online.target systemd-networkd-wait-online.service
+{% endif %}
 
 [Service]
-Restart=on-failure
-StartLimitInterval=86400
-StartLimitBurst=5
+Restart={{ caddy_systemd_restart }}
+StartLimitInterval={{ caddy_systemd_restart_startlimitinterval }}
+StartLimitBurst= {{ caddy_systemd_restart_startlimitburst }}
 
 ; User and group the process will run as.
 User={{ caddy_user }}


### PR DESCRIPTION
Default systemd unit file fails (at least) with Ubuntu 16.04. This can be avoided by disabling the network dependency.

Furthermore, the more configuration options, the better :)