### PR TITLE
Make the architecture configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # defaults file for caddy-ansible
+caddy_arch: amd64
 caddy_user: www-data
 caddy_home: /home/caddy
 caddy_features: http.git

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,12 +15,12 @@
   register: caddy_features_cache
 
 - name: Download Caddy
-  get_url: url=https://caddyserver.com/download/linux/amd64?plugins={{ caddy_features }} dest={{ caddy_home }}/caddy.tar.gz force=yes
+  get_url: url=https://caddyserver.com/download/linux/{{ caddy_arch }}?plugins={{ caddy_features }} dest={{ caddy_home }}/caddy.tar.gz force=yes
   when: caddy_releases_cache.changed or caddy_features_cache.changed
   register: caddy_binary_cache
 
 - name: Download Caddy
-  get_url: url=https://caddyserver.com/download/linux/amd64?plugins={{ caddy_features }} dest={{ caddy_home }}/caddy.tar.gz
+  get_url: url=https://caddyserver.com/download/linux/{{ caddy_arch }}?plugins={{ caddy_features }} dest={{ caddy_home }}/caddy.tar.gz
 
 - name: Extract Caddy
   unarchive: src={{ caddy_home }}/caddy.tar.gz dest={{ caddy_home }} copy=no owner={{ caddy_user }}


### PR DESCRIPTION
This is a simple change to make it possible for the user to specify the caddy architecture to download. The default is left as 'amd64' for backwards compatibility and because that is likely the most common architecture used. This change allows the playbook to be used to install on a raspberry pi.