### PR TITLE
Unit file should not be executable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,7 +61,7 @@
   notify: Restart Caddy
 
 - name: Systemd service
-  template: src=caddy.service dest=/etc/systemd/system/caddy.service mode=0755
+  template: src=caddy.service dest=/etc/systemd/system/caddy.service mode=0644
   when: systemd.stat.exists
   notify: Reload systemd service file
 


### PR DESCRIPTION
Prevents notices like this:

May  1 11:58:26 lb-1 systemd[1]: Configuration file /etc/systemd/system/caddy.service is marked executable. Please remove executable permission bits. Proceeding anyway.