### PR TITLE
Add option to globally disable http2 protocol

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ caddy_conf_dir: /etc/caddy
 caddy_log_dir: /var/log/caddy
 caddy_log_file: stdout
 caddy_certs_dir: /etc/ssl/caddy
+caddy_http2_enabled: "true"
 caddy_systemd_network_dependency: True
 caddy_systemd_restart: "on-failure" # alway, on-success, on-failure, on-abnormal, on-abort, on-watchdog
 caddy_systemd_restart_startlimitinterval: "86400"

--- a/templates/caddy.conf
+++ b/templates/caddy.conf
@@ -25,5 +25,5 @@ limit nofile 1048576 1048576
 script
         cd {{ caddy_certs_dir }}
         rootdir="$(mktemp -d -t "caddy-run.XXXXXX")"
-        exec {{ caddy_bin_dir }}/caddy -agree -log={{ caddy_log_file }} -conf={{ caddy_conf_dir }}/Caddyfile -root=$rootdir
+        exec {{ caddy_bin_dir }}/caddy -agree -log={{ caddy_log_file }} -http2={{ caddy_http2_enabled }} -conf={{ caddy_conf_dir }}/Caddyfile -root=$rootdir
 end script

--- a/templates/caddy.conf.centos-6
+++ b/templates/caddy.conf.centos-6
@@ -28,5 +28,5 @@ limit nofile 1048576 1048576
 script
         cd {{ caddy_certs_dir }}
         rootdir="$(mktemp -d -t "caddy-run.XXXXXX")"
-        exec {{ caddy_bin_dir }}/caddy -agree -log=stdout -conf={{ caddy_conf_dir }}/Caddyfile -root=$rootdir
+        exec {{ caddy_bin_dir }}/caddy -agree -log={{ caddy_log_file }} -http2={{ caddy_http2_enabled }} -conf={{ caddy_conf_dir }}/Caddyfile -root=$rootdir
 end script

--- a/templates/caddy.conf.ubuntu-12.04
+++ b/templates/caddy.conf.ubuntu-12.04
@@ -26,5 +26,5 @@ limit nofile 1048576 1048576
 script
         cd {{ caddy_certs_dir }}
         rootdir="$(mktemp -d -t "caddy-run.XXXXXX")"
-        exec {{ caddy_bin_dir }}/caddy -agree -log={{ caddy_log_file }} -conf={{ caddy_conf_dir }}/Caddyfile -root=$rootdir
+        exec {{ caddy_bin_dir }}/caddy -agree -log={{ caddy_log_file }} -http2={{ caddy_http2_enabled }} -conf={{ caddy_conf_dir }}/Caddyfile -root=$rootdir
 end script

--- a/templates/caddy.service
+++ b/templates/caddy.service
@@ -25,7 +25,7 @@ Group={{ caddy_user }}
 Environment=CADDYPATH={{ caddy_certs_dir }}
 
 ; Always set "-root" to something safe in case it gets forgotten in the Caddyfile.
-ExecStart={{ caddy_bin_dir }}/caddy -log {{ caddy_log_file }} -agree=true -conf={{ caddy_conf_dir }}/Caddyfile -root=/var/tmp
+ExecStart={{ caddy_bin_dir }}/caddy -log {{ caddy_log_file }} -http2={{ caddy_http2_enabled }} -agree=true -conf={{ caddy_conf_dir }}/Caddyfile -root=/var/tmp
 ExecReload=/bin/kill -USR1 $MAINPID
 
 ; Limit the number of file descriptors; see `man systemd.exec` for more limit settings.


### PR DESCRIPTION
https://caddyserver.com/docs/cli

Proxy and HTTP2 has some bugs which somethings results in 502 errors. Until this is resolved, easiest option is to disable http2. By default this will have http2 enabled, it only add an option to disable.

More info: https://github.com/mholt/caddy/issues/1080