### PR TITLE
Relax permissions on caddy_log_dir

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,9 @@
   with_items:
     - "{{ caddy_conf_dir }}"
     - "{{ caddy_certs_dir }}"
-    - "{{ caddy_log_dir }}"
+
+- name: Create log directory
+  file: path={{ caddy_log_dir }} state=directory owner={{ caddy_user }} mode='0775'
 
 - name: Create Caddyfile
   copy: content="{{ caddy_config }}" dest="{{ caddy_conf_dir }}/Caddyfile" owner={{ caddy_user }}


### PR DESCRIPTION
The permissions on the caddy_log_dir are unnecessarily strict. Allow read-access from "other".

The default ansible config has caddy logging to stdout, but it does create a caddy_log_dir defaulting to /var/log/caddy. If you change caddy's configuration to make use of that directory, normal unprivileged users won't be able to look at log files because the permissions are set to 0770. This PR relaxes the permissions on the log directory to align with permissions on log-files that caddy creates (0666).

This is especially useful if you use a log parser like goaccess https://github.com/allinurl/goaccess that you don't want to execute as a privileged user.