### PR TITLE
Verify sigs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ default:
 ```
 caddy_setcap: yes
 ```
-
+**Verify the PGP signature on download?**<br>
+```
+caddy_pgp_verify_signatures: no
+```
 **Use systemd capabilities controls**<br>
 default:
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,10 @@ caddy_systemd_private_devices: "true"
 caddy_systemd_protect_home: "true"
 caddy_systemd_protect_system: "full"
 caddy_setcap: yes
+caddy_pgp_key_id: 65760C51EDEA2017CEA2CA15155B6D79CA56EA34
+caddy_pgp_key_server: hkp://keyserver.ubuntu.com
+caddy_pgp_recv_timeout: 60
+caddy_pgp_verify_signatures: no
 caddy_config: |
   localhost:2020
   gzip

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,28 @@
 - name: Download Caddy
   get_url: url=https://caddyserver.com/download/linux/{{ caddy_arch }}?plugins={{ caddy_features }} dest={{ caddy_home }}/caddy.tar.gz
 
+- name: Check if Caddy PGP key is already in keyring
+  command: gpg --list-keys {{ caddy_pgp_key_id }}
+  changed_when: gpg_list_keys|failed
+  register: gpg_list_keys
+  when: caddy_pgp_verify_signatures
+  failed_when: "gpg_list_keys|failed and ('gpg: error reading key: No public key' not in gpg_list_keys.stderr and
+                                          'gpg: error reading key: public key not found' not in gpg_list_keys.stderr)"
+
+- name: Download Caddy PGP key
+  command: gpg --keyserver-options timeout={{ caddy_pgp_recv_timeout }} --keyserver {{ caddy_pgp_key_server }} --recv-keys {{ caddy_pgp_key_id }}
+  when: caddy_pgp_verify_signatures and gpg_list_keys.changed
+  register: caddy_pgp_key
+  changed_when: '"imported" in caddy_pgp_key.stdout'
+
+- name: Download Caddy signature
+  get_url: url=https://caddyserver.com/download/linux/{{ caddy_arch }}/signature?plugins={{ caddy_features }} dest={{ caddy_home }}/caddy.tar.gz.asc timeout=60
+  when: caddy_pgp_verify_signatures
+
+- name: Verify Caddy signature
+  command: gpg --verify {{ caddy_home }}/caddy.tar.gz.asc {{ caddy_home }}/caddy.tar.gz
+  when: caddy_pgp_verify_signatures
+
 - name: Extract Caddy
   unarchive: src={{ caddy_home }}/caddy.tar.gz dest={{ caddy_home }} copy=no owner={{ caddy_user }}
   when: caddy_binary_cache.changed


### PR DESCRIPTION
Allows verification of the PGP signature which is available on the caddy website. The Caddy key will be downloaded if is not already in the keyring for the user who the role runs as.

I have left the new functionality disabled by default for backwards compatibility reasons.