### PR TITLE
Additional environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,17 @@ Supported:
 
 RHEL/CentOS has no release that supports systemd capability controls at this time.
 
+**Add additional environment variables**<br>
 
-Example Playbook
+Add environment variables to the systemd/upstart script
+
+```
+caddy_environment_variables:
+  FOO: bar
+  SECONDVAR: spam
+```
+
+Example Playbooks
 ----------------
 ```
 ---
@@ -74,6 +83,31 @@ Example Playbook
 
         root /var/www
         git github.com/antoiner77/caddy-ansible
+```
+
+Example with Cloudflare DNS for TLS 
+
+```
+---
+- hosts: all
+  roles:
+    - role: caddy-ansible
+      caddy_features: tls.dns.cloudflare
+      caddy_environment_variables:
+        CLOUDFLARE_EMAIL: your@email.com
+        CLOUDFLARE_API_KEY: 1234567890
+      caddy_config: |
+        yourcloudflareddomain.com {
+    
+            tls {
+                dns cloudflare
+            }
+            
+            gzip
+    
+            root /var/www
+            git github.com/antoiner77/caddy-ansible
+        }
 ```
 
 Debugging

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,4 +33,4 @@ caddy_config: |
   # root /var/www
   git github.com/antoiner77/caddy-ansible
 
-caddy_environment_variables: ""
+caddy_environment_variables: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,3 +32,5 @@ caddy_config: |
   # tls email@example.com
   # root /var/www
   git github.com/antoiner77/caddy-ansible
+
+caddy_environment_variables: ""

--- a/templates/caddy.conf
+++ b/templates/caddy.conf
@@ -19,7 +19,15 @@ reload signal SIGUSR1
 
 # Let's Encrypt certificates will be written to this directory.
 env CADDYPATH={{ caddy_certs_dir }}
+{% if caddy_environment_variables|length %}
 
+# Additional environment variables:
+
+{% for key, value in caddy_environment_variables.items() %}
+env {{ key }}={{ value }}
+{% endfor %}
+
+{% endif %}
 limit nofile 1048576 1048576
 
 script

--- a/templates/caddy.conf
+++ b/templates/caddy.conf
@@ -19,6 +19,7 @@ reload signal SIGUSR1
 
 # Let's Encrypt certificates will be written to this directory.
 env CADDYPATH={{ caddy_certs_dir }}
+
 {% if caddy_environment_variables|length %}
 
 # Additional environment variables:

--- a/templates/caddy.conf.centos-6
+++ b/templates/caddy.conf.centos-6
@@ -22,6 +22,7 @@ reload signal SIGUSR1
 
 # Let's Encrypt certificates will be written to this directory.
 env CADDYPATH={{ caddy_certs_dir }}
+
 {% if caddy_environment_variables|length %}
 
 # Additional environment variables:

--- a/templates/caddy.conf.centos-6
+++ b/templates/caddy.conf.centos-6
@@ -22,7 +22,15 @@ reload signal SIGUSR1
 
 # Let's Encrypt certificates will be written to this directory.
 env CADDYPATH={{ caddy_certs_dir }}
+{% if caddy_environment_variables|length %}
 
+# Additional environment variables:
+
+{% for key, value in caddy_environment_variables.items() %}
+env {{ key }}={{ value }}
+{% endfor %}
+
+{% endif %}
 limit nofile 1048576 1048576
 
 script

--- a/templates/caddy.conf.ubuntu-12.04
+++ b/templates/caddy.conf.ubuntu-12.04
@@ -20,6 +20,7 @@ respawn limit 10 5
 
 # Let's Encrypt certificates will be written to this directory.
 env CADDYPATH={{ caddy_certs_dir }}
+
 {% if caddy_environment_variables|length %}
 
 # Additional environment variables:

--- a/templates/caddy.conf.ubuntu-12.04
+++ b/templates/caddy.conf.ubuntu-12.04
@@ -20,7 +20,15 @@ respawn limit 10 5
 
 # Let's Encrypt certificates will be written to this directory.
 env CADDYPATH={{ caddy_certs_dir }}
+{% if caddy_environment_variables|length %}
 
+# Additional environment variables:
+
+{% for key, value in caddy_environment_variables.items() %}
+env {{ key }}={{ value }}
+{% endfor %}
+
+{% endif %}
 limit nofile 1048576 1048576
 
 script

--- a/templates/caddy.service
+++ b/templates/caddy.service
@@ -24,6 +24,7 @@ Group={{ caddy_user }}
 ; Letsencrypt-issued certificates will be written to this directory.
 Environment=CADDYPATH={{ caddy_certs_dir }}
 
+
 ; Always set "-root" to something safe in case it gets forgotten in the Caddyfile.
 ExecStart={{ caddy_bin_dir }}/caddy -log {{ caddy_log_file }} -http2={{ caddy_http2_enabled }} -agree=true -conf={{ caddy_conf_dir }}/Caddyfile -root=/var/tmp
 ExecReload=/bin/kill -USR1 $MAINPID
@@ -52,6 +53,15 @@ ReadWriteDirectories={{ caddy_certs_dir }}
 CapabilityBoundingSet={{ caddy_systemd_capabilities }}
 AmbientCapabilities={{ caddy_systemd_capabilities }}
 NoNewPrivileges=true
+
+{% endif %}
+{% if caddy_environment_variables|length %}
+
+; Additional environment variables:
+
+{% for key, value in caddy_environment_variables.items() %}
+Environment={{ key }}={{ value }}
+{% endfor %}
 
 {% endif %}
 [Install]


### PR DESCRIPTION
I've added the option of additional environment variables to be passed with the systemd or upstart scripts. I personally needed this for Cloudflare DNS TLS certification. I've also added an example to that extend.