### PR TITLE
Always download the signature & replace when needed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
   changed_when: '"imported" in caddy_pgp_key.stdout'
 
 - name: Download Caddy signature
-  get_url: url=https://caddyserver.com/download/linux/{{ caddy_arch }}/signature?plugins={{ caddy_features }} dest={{ caddy_home }}/caddy.tar.gz.asc timeout=60
+  get_url: url=https://caddyserver.com/download/linux/{{ caddy_arch }}/signature?plugins={{ caddy_features }} dest={{ caddy_home }}/caddy.tar.gz.asc timeout=60 force=yes
   when: caddy_pgp_verify_signatures
 
 - name: Verify Caddy signature

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,7 @@
 
 - name: Download Caddy
   get_url: url=https://caddyserver.com/download/linux/{{ caddy_arch }}?plugins={{ caddy_features }} dest={{ caddy_home }}/caddy.tar.gz
+  register: caddy_download
 
 - name: Check if Caddy PGP key is already in keyring
   command: gpg --list-keys {{ caddy_pgp_key_id }}
@@ -38,11 +39,11 @@
 
 - name: Download Caddy signature
   get_url: url=https://caddyserver.com/download/linux/{{ caddy_arch }}/signature?plugins={{ caddy_features }} dest={{ caddy_home }}/caddy.tar.gz.asc timeout=60 force=yes
-  when: caddy_pgp_verify_signatures
+  when: caddy_pgp_verify_signatures and (caddy_binary_cache.changed or caddy_download.changed)
 
 - name: Verify Caddy signature
   command: gpg --verify {{ caddy_home }}/caddy.tar.gz.asc {{ caddy_home }}/caddy.tar.gz
-  when: caddy_pgp_verify_signatures
+  when: caddy_pgp_verify_signatures and (caddy_binary_cache.changed or caddy_download.changed)
 
 - name: Extract Caddy
   unarchive: src={{ caddy_home }}/caddy.tar.gz dest={{ caddy_home }} copy=no owner={{ caddy_user }}


### PR DESCRIPTION
This prevents an issue where the wrong signature would be used when the role was run for a second time (assuming that a new version of Caddy had been released between runs) due to the original signature remaining in place. The old signature was obviously not valid for the new version of Caddy so caused a failure.

Apologies for introducing the buggy change in the first place!