### PR TITLE
Fixing README.md to change the features

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ tls.dns.rackspace, tls.dns.rfc2136, tls.dns.route53, tls.dns.vultr
 Changing this variable will reinstall Caddy with the new features if `caddy_update` is enabled<br>
 default:
 ```
-caddy_features: git
+caddy_features: http.git
 ```
 **Use `setcap` for allowing Caddy to open a low port (e.g. 80, 443)?**<br>
 default:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,17 @@ default:
 ```
 caddy_update: yes
 ```
-**Features that can be added to core:** DNS, awslambda, cors, expires, filemanager, filter, git, hugo, ipfilter, jsonp, jwt, locale, mailout, minify, multipass, prometheus, ratelimit, realip, search, upload<br>
+**Features that can be added to core:** http.authz, http.awses, http.awslambda, 
+http.cache, http.cgi, http.cors, http.datadog, http.expires, http.filemanager, 
+http.filter, http.forwardproxy, http.git, http.gopkg, http.grpc, http.hugo, 
+http.ipfilter, http.jekyll, http.jwt, http.locale, http.login, http.mailout, 
+http.minify, http.nobots, http.prometheus, http.proxyprotocol, http.ratelimit, 
+http.realip, http.reauth, http.restic, http.upload, http.webdav, dns, net, 
+hook.service, tls.dns.azure, tls.dns.cloudflare, tls.dns.digitalocean, 
+tls.dns.dnsimple, tls.dns.dnspod, tls.dns.dyn, tls.dns.exoscale, tls.dns.gandi, 
+tls.dns.googlecloud, tls.dns.linode, tls.dns.namecheap, tls.dns.ovh, 
+tls.dns.rackspace, tls.dns.rfc2136, tls.dns.route53, tls.dns.vultr   
+
 Changing this variable will reinstall Caddy with the new features if `caddy_update` is enabled<br>
 default:
 ```


### PR DESCRIPTION
Hi,
I noticed today that the way described in the README.md to add features to the caddy binary doesn't work anymore. For example : [https://caddyserver.com/download/linux/amd64?plugins=ipfilter](https://caddyserver.com/download/linux/amd64?plugins=ipfilter) doesn't work anymore to add the ipfilter plugin. It needs to be renamed to `http.ipfilter`.

This PR intends to modify the README.md file and add all the missing plugins and fix the way they are called. 