### PR TITLE
Implement support for new license parameters on download

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ caddy_config: |
   root /var/www
   git github.com/antoiner77/caddy-ansible
 ```
+**The type of license to use**<br>
+default:
+```
+caddy_license: personal
+```
+If you set the license type to `commercial` then you should also specify (replacing the dummy values with your real ones):
+```
+caddy_license_account_id: YOUR_ACCOUNT_ID
+caddy_license_api_key: YOUR_API_KEY
+```
 **Auto update Caddy?**<br>
 default:
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ caddy_features: http.git
 caddy_update: yes
 caddy_bin_dir: /usr/local/bin
 caddy_conf_dir: /etc/caddy
+caddy_license: personal
+caddy_license_account_id:
+caddy_license_api_key:
 caddy_log_dir: /var/log/caddy
 caddy_log_file: stdout
 caddy_certs_dir: /etc/ssl/caddy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,13 +14,28 @@
   when: caddy_update
   register: caddy_features_cache
 
+- name: Build base URL
+  set_fact:
+    caddy_base_url: "https://{{ caddy_license_account_id }}:{{ caddy_license_api_key }}@caddyserver.com/download/linux/{{ caddy_arch }}"
+  when: caddy_license != 'personal'
+
+- name: Build base URL
+  set_fact:
+    caddy_base_url: "https://caddyserver.com/download/linux/{{ caddy_arch }}"
+  when: caddy_license == 'personal'
+
+- name: Build request URLs
+  set_fact:
+    caddy_url: "{{ caddy_base_url }}?plugins={{ caddy_features }}&license={{ caddy_license }}"
+    caddy_sig_url: "{{ caddy_base_url }}/signature?plugins={{ caddy_features }}&license={{ caddy_license }}"
+
 - name: Download Caddy
-  get_url: url=https://caddyserver.com/download/linux/{{ caddy_arch }}?plugins={{ caddy_features }} dest={{ caddy_home }}/caddy.tar.gz force=yes
+  get_url: url={{ caddy_url }} dest={{ caddy_home }}/caddy.tar.gz force_basic_auth={{ caddy_license != 'personal' }} force=yes
   when: caddy_releases_cache.changed or caddy_features_cache.changed
   register: caddy_binary_cache
 
 - name: Download Caddy
-  get_url: url=https://caddyserver.com/download/linux/{{ caddy_arch }}?plugins={{ caddy_features }} dest={{ caddy_home }}/caddy.tar.gz
+  get_url: url={{ caddy_url}} dest={{ caddy_home }}/caddy.tar.gz force_basic_auth={{ caddy_license != 'personal' }}
   register: caddy_download
 
 - name: Check if Caddy PGP key is already in keyring
@@ -38,7 +53,7 @@
   changed_when: '"imported" in caddy_pgp_key.stdout'
 
 - name: Download Caddy signature
-  get_url: url=https://caddyserver.com/download/linux/{{ caddy_arch }}/signature?plugins={{ caddy_features }} dest={{ caddy_home }}/caddy.tar.gz.asc timeout=60 force=yes
+  get_url: url={{ caddy_sig_url }} dest={{ caddy_home }}/caddy.tar.gz.asc timeout=60 force=yes force_basic_auth={{ caddy_license != 'personal' }}
   when: caddy_pgp_verify_signatures and (caddy_binary_cache.changed or caddy_download.changed)
 
 - name: Verify Caddy signature


### PR DESCRIPTION
As discussed in https://github.com/antoiner77/caddy-ansible/issues/66 this adds support for the new license parameter on download (and allows the user to provide their license details if they have a commercial license).

I don't have a commercial caddy license so I haven't been able to properly test that part. I have tested that it sends the credentials but they get rejected by the caddy server. Would be ideal if someone with a commercial license could test.