### PR TITLE
Adjust systemd LimitNPROC

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,7 @@ caddy_systemd_private_tmp: "true"
 caddy_systemd_private_devices: "true"
 caddy_systemd_protect_home: "true"
 caddy_systemd_protect_system: "full"
+caddy_systemd_nproc_limit: 0
 caddy_setcap: yes
 caddy_pgp_key_id: 65760C51EDEA2017CEA2CA15155B6D79CA56EA34
 caddy_pgp_key_server: hkp://keyserver.ubuntu.com

--- a/templates/caddy.service
+++ b/templates/caddy.service
@@ -31,8 +31,10 @@ ExecReload=/bin/kill -USR1 $MAINPID
 
 ; Limit the number of file descriptors; see `man systemd.exec` for more limit settings.
 LimitNOFILE=1048576
-; Unmodified caddy is not expected to use more than that.
-LimitNPROC=64
+{% if caddy_systemd_nproc_limit > 0 %}
+; Limit the number of caddy threads.
+LimitNPROC={{ caddy_systemd_nproc_limit }}
+{% endif %}
 
 ; Use private /tmp and /var/tmp, which are discarded after caddy stops.
 PrivateTmp={{ caddy_systemd_private_tmp }}


### PR DESCRIPTION
* Add a configuration variable for systemd `LimitNPROC`.
* Default to disabled to avoid crashing Caddy.

Closes: https://github.com/antoiner77/caddy-ansible/issues/69