### PR TITLE
Prevent ripgrep error on .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .vagrant
 *.retry
 .molecule
-**__pycache__**
+__pycache__/


### PR DESCRIPTION
The current .gitignore works fine but when using ripgrep (https://github.com/BurntSushi/ripgrep) on a directory containing this repo it outputs this error:

```
line 4: error parsing glob '**__pycache__**': invalid use of **; must be one path component
```

This pull request changes the problem line to an equivalent one which does not provoke the error.

I thought about taking this up as an issue on ripgrep but I checked the documentation at https://git-scm.com/docs/gitignore#_pattern_format and it states that use of `**` in patterns should always be adjacent to at least one `/` or it will be invalid. This means that I think it's best to change it here.

I found 2 other ways of excluding the same files:

```
**/__pycache__/**
```

and

```
__pycache__/
```

neither of which produce the error in ripgrep. I chose the second option mainly because it's shorter so I'd be happy to go with whichever version people think is clearer.

To test this you could run these commands from the root of the repo:

```bash
mkdir -p __pycache__
touch __pycache__/.keep
mkdir -p defaults/__pycache__
touch defaults/__pycache__/.keep
mkdir -p defaults/test/__pycache__
touch defaults/test/__pycache__/.keep
```

On the current master all of these files will be excluded. The same is true with the changes here. If you remove the line you will see all the files/directories get picked up by git on `git status`.
