### PR TITLE
Add an example of how to load a template for the config from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ caddy_config: |
   root /var/www
   git github.com/antoiner77/caddy-ansible
 ```
+
+If you wish to use a template for the config you can do this:
+```
+caddy_config: "{{ lookup('template', 'templates/Caddyfile.j2') }}"
+```
+
 **The type of license to use**<br>
 default:
 ```


### PR DESCRIPTION
This should make it clear for anyone who is unaware how the config can be loaded as a template. It is also possible to use the 'file' lookup plugin to load it from a file (without performing templating) but I didn't add an example of that because it seemed less useful. I would be happy to add it if you would like that though.

This should resolve https://github.com/antoiner77/caddy-ansible/issues/45