### PR TITLE
Add quote on caddy url for escape URL with parameters.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
     caddy_sig_url: "{{ caddy_base_url }}/signature?plugins={{ caddy_features }}&license={{ caddy_license }}"
 
 - name: Download Caddy
-  get_url: url={{ caddy_url }} dest={{ caddy_home }}/caddy.tar.gz force_basic_auth={{ caddy_license != 'personal' }} force=yes
+  get_url: url={{ caddy_url | quote }} dest={{ caddy_home }}/caddy.tar.gz force_basic_auth={{ caddy_license != 'personal' }} force=yes
   when: caddy_releases_cache.changed or caddy_features_cache.changed
   register: caddy_binary_cache
   tags: skip_ansible_lint


### PR DESCRIPTION
As title, when i include some plugin ansible fail with this error:
```
TASK [antoiner77.caddy : Download Caddy] ****************************************************************************************************************************************************************************************************************************************
fatal: [gitlab-criptalia]: FAILED! => {"changed": false, "dest": "/home/caddy/caddy.tar.gz", "msg": "Connection failure: ('The read operation timed out',)", "state": "absent", "url": "https://caddyserver.com/download/linux/amd64?plugins=tls.dns.route53&license=personal"}  
        to retry, use: --limit @/home/cani/Develop/common-playbook/provisioning/gitlab-server.retry                                                                                                                                                                              
    
```