### PR TITLE
Don't use the quote filter on the url

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,7 @@
 
 - name: Download Caddy
   get_url:
-    url: "{{ caddy_url | quote }}"
+    url: "{{ caddy_url }}"
     dest: "{{ caddy_home }}/caddy.tar.gz"
     force_basic_auth: "{{ caddy_license != 'personal' }}"
     force: yes
@@ -53,7 +53,7 @@
 
 - name: Download Caddy
   get_url:
-    url: "{{ caddy_url}}"
+    url: "{{ caddy_url }}"
     dest: "{{ caddy_home }}/caddy.tar.gz"
     force_basic_auth: "{{ caddy_license != 'personal' }}"
     timeout: 300


### PR DESCRIPTION
This causes the following error when downloading caddy:
     Request failed: <urlopen error unknown url type: 'https>
I am able to reproduce this by running the tests so it definitely seems worth addressing.

Also possibly worth mentioning is that the Travis tests have not run for 3 months.