### PR TITLE
Flush handlers to prevent the restart failing when the service changes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -185,6 +185,9 @@
     state: present
   when: caddy_setcap
 
+- name: Force systemd reload
+  meta: flush_handlers
+
 - name: Start Caddy service
   service:
     name: caddy


### PR DESCRIPTION
I found that when the systemd service gets changed (but it is not being installed for the first time) the final step can fail because systemd will not be able to start caddy due to the fact that the service file has been changed on disk (so a `daemon-reload` is needed). The role already has a handler which does the `systemctl daemon-reload` so this just ensures that is called (if needed) before ensuring the role is started.