### PR TITLE
Correct name of test playbook

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provision "ansible" do |ansible|
-      ansible.playbook = 'tests/test.yml'
+    ansible.playbook = 'tests/playbook.yml'
   end
 
   $script = <<SCRIPT
@@ -43,6 +43,7 @@ Vagrant.configure(2) do |config|
     *)       echo "$http_code | Unknown http response code!" >&2 ;;
   esac
 SCRIPT
+
   # Fix 'stdin: is not a tty' error
   config.ssh.pty = true
   config.vm.provision :shell, inline: $script


### PR DESCRIPTION
Currently the `Vagrantfile` refers to `tests/test.yml` which does not exist. I changed this to point to `tests/playbook.yml` which enabled me to run the tests.