### PR TITLE
Use comment filter with ansible_managed

### DIFF
--- a/templates/caddy.service
+++ b/templates/caddy.service
@@ -1,5 +1,4 @@
-; {{ ansible_managed }}
-;
+{{ ansible_managed | comment(decoration="; ") }}
 ; source: https://github.com/mholt/caddy/blob/master/dist/init/linux-systemd/caddy.service
 ; version: 6be0386
 ; changes: Set variables via Ansible


### PR DESCRIPTION
Use a `comment` filter[0] to decorate the `ansible_managed` template.
This allows for multi-line messages.

[0]: https://docs.ansible.com/ansible/2.5/user_guide/playbooks_filters.html#comment-filter