### PR TITLE
Update architecture names for caddy build server

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,5 +4,5 @@ go_arch_map:
   i386: '386'
   x86_64: 'amd64'
   aarch64: 'arm64'
-  armv7l: 'armv7'
-  armv6l: 'armv6'
+  armv7l: 'arm7'
+  armv6l: 'arm6'


### PR DESCRIPTION
I found that the build server currently requires `arm6` and `arm7` (no `v`) for these architectures. You can check this by visiting https://caddyserver.com/download and selecting one of these architectures and checking the generated download link.