### PR TITLE
Fix search filter

### DIFF
--- a/tasks/packages-apt.yml
+++ b/tasks/packages-apt.yml
@@ -9,7 +9,7 @@
   apt:
     name: git
     state: present
-  when: caddy_features | search('git')
+  when: caddy_features is search('git')
 
 - name: Install libcap
   apt:

--- a/tasks/packages-dnf.yml
+++ b/tasks/packages-dnf.yml
@@ -4,4 +4,4 @@
   dnf:
     name: git
     state: present
-  when: caddy_features | search('git')
+  when: caddy_features is search('git')

--- a/tasks/packages-pacman.yml
+++ b/tasks/packages-pacman.yml
@@ -4,4 +4,4 @@
   pacman:
     name: git
     state: present
-  when: caddy_features | search('git')
+  when: caddy_features is search('git')

--- a/tasks/packages-yum.yml
+++ b/tasks/packages-yum.yml
@@ -4,4 +4,4 @@
   yum:
     name: git
     state: present
-  when: caddy_features | search('git')
+  when: caddy_features is search('git')


### PR DESCRIPTION
Changing the way how search filter is working.

Currently I'm getting the warining:

```text
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|search` use `result is search`. This feature will be removed in version 2.9. Deprecation warnings can 
be disabled by setting deprecation_warnings=False in ansible.cfg.
```

This PR is fixing it...